### PR TITLE
フロントから API を叩けるように変更

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,3 +1,5 @@
+APP_ORIGIN=http://localhost:3000
+
 DB_TYPE=mysql
 DB_HOST=db
 DB_PORT=3306

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,25 @@
 from fastapi import FastAPI
 from routers import router
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+import os
+
+# .env ファイルの読み込み
+load_dotenv()
 
 # アプリケーションインスタンスを生成
 app = FastAPI()
 
 # ルーティングの読み込み
 app.include_router(router)
+
+# ミドルウェアの追加
+app.add_middleware(
+    CORSMiddleware,
+    # アクセスを許可するオリジン
+    allow_origins=[os.getenv("APP_ORIGIN")],
+    # 全てのリクエストメソッドを許可(["GET", "POST"]など個別指定も可能)
+    allow_methods=["*"],
+    # アクセス可能なレスポンスヘッダーを設定（今回は必要ない）
+    allow_headers=["*"],
+)

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_ENDPOINT="http://localhost:8000"

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/app/docker/bin/command.sh
+++ b/app/docker/bin/command.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# .env ファイルが無ければ .env.example からコピーする
+if [ ! -e "/usr/src/app/.env" ]; then
+    cp /usr/src/app/.env.example /usr/src/app/.env
+fi
+
 # モジュールのインストール
 npm install
 

--- a/app/src/config/index.ts
+++ b/app/src/config/index.ts
@@ -1,0 +1,4 @@
+/**
+ * バックエンド URL
+ */
+export const API_ENDPOINT: string = process.env.REACT_APP_API_ENDPOINT ?? "http://localhost:8000"

--- a/app/src/libs/axios.ts
+++ b/app/src/libs/axios.ts
@@ -1,0 +1,9 @@
+import Axios from "axios";
+import { API_ENDPOINT } from "../config";
+
+/**
+ * バックエンドのAPIを叩く際に利用する axios インスタンス
+ */
+export const axios = Axios.create({
+  baseURL: API_ENDPOINT,
+});


### PR DESCRIPTION
## 関連

- なし

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [x] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [x] その他

## 変更の詳細

**`api/.env.example`**

- アクセスを許可するオリジンを環境変数に追加

**`api/main.py`**

- CORS エラーを防ぐための設定を追加

**`app/.env.example`**

- バックエンドのAPIをたたくための URL を環境変数に追加

**`app/.gitignore`**

- 環境変数ファイルを git 管理から除外

**`app/docker/bin/command.sh`**

- `app/.env` ファイルがなければ `app/.env.example` ファイルからコピーする処理を追加

**`app/src/config/index.ts`**

- 設定値をまとめた設定ファイルを作成

**`app/src/libs/axios.ts`**

- バックエンドAPI をたたく際に利用する axios インスタンスを作成

## 動作確認

- フロントエンドから追加した axios インスタンスを利用してバックエンドの api をたたけることを確認

## その他

- なし