### PR TITLE
神経衰弱ゲームで表示するペア数を指定できるように変更

### DIFF
--- a/app/src/features/pelmanism/components/Pelmanism.tsx
+++ b/app/src/features/pelmanism/components/Pelmanism.tsx
@@ -1,10 +1,10 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React from "react";
 import { usePelmanism } from "../api/getPelmanism";
 import { is_set } from "../../../utils/isType";
 import { PelmanismItem, PelmanismResponse } from "../types";
-import { shuffleArray } from "../../../utils/array";
+import { getRandomValues, shuffleArray } from "../../../utils/array";
 
-export function Pelmanism() {
+export function Pelmanism({ pairNumber }: {pairNumber: number}) {
   const [pelmanismItems, setPelmanismItems] = React.useState<PelmanismItem[]>([]);
   const [openItems, setOpenItems] = React.useState<PelmanismItem[]>([]);
   const [isShows, setIsShows] = React.useState<boolean[]>([]);
@@ -13,9 +13,10 @@ export function Pelmanism() {
 
   React.useEffect(() => {
     if (is_set<PelmanismResponse[]>(pelmanismQuery.data)) {
-      const items = pelmanismQuery.data.map((item) => [{id: item.id, text: item.kansai}, {id: item.id, text: item.default}]);
-      setPelmanismItems(shuffleArray(items.flat()));
-      setIsShows(new Array(pelmanismQuery.data.length * 2).fill(false));
+      const randomItems = getRandomValues<PelmanismResponse>(pelmanismQuery.data, pairNumber);
+      const items = randomItems.map((item) => [{id: item.id, text: item.kansai}, {id: item.id, text: item.default}]);
+      setPelmanismItems(shuffleArray<PelmanismItem>(items.flat()));
+      setIsShows(new Array(items.length).fill(false));
     }
   }, [pelmanismQuery.data]);
 
@@ -39,6 +40,7 @@ export function Pelmanism() {
       return;
     }
 
+    console.log(isShows);
     const resetIsShows = newIsShows.map((value, itemIndex) => pelmanismItems[itemIndex].id === openItems[0].id || pelmanismItems[itemIndex].id === item.id ? false : value);
     setIsResetting(true);
 

--- a/app/src/utils/array.ts
+++ b/app/src/utils/array.ts
@@ -8,3 +8,8 @@ export function shuffleArray<T>(array: T[]): T[] {
 
   return result;
 }
+
+export function getRandomValues<T>(array: T[], count: number): T[] {
+  const offset = Math.min(array.length, count);
+  return shuffleArray(array).slice(0, offset);
+}


### PR DESCRIPTION
## 関連

- なし

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [x] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

**`app/src/features/pelmanism/components/Pelmanism.tsx`**

- 神経衰弱ゲームで表示するpair数を指定できるように変更

**`app/src/utils/array.ts`**

- 配列の中から指定された数ランダムに取得する関数を作成

## 動作確認

- 指定されたペア数だけ表示されていることを確認
- ゲーム終了までエラーが発生しないことを確認

## その他

なし