### PR TITLE
ゲームクリア画面からタイトルへ戻るリンクを修正

### DIFF
--- a/app/src/components/Game/gameClearCompornent.tsx
+++ b/app/src/components/Game/gameClearCompornent.tsx
@@ -51,7 +51,7 @@ export const GameClearComponent = () => {
                         <img src={goalimage} alt="失敗" width={650}/>
                     </Box>
                     <Box sx={{display: "flex", justifyContent: "center", alignItems: "center", flex: 1}}>
-                    <Button variant="contained" color="inherit" href="../../pages/Home.tsx" sx={{ fontSize: "18px", position: "relative", width: '200px', height: '50px', }}>
+                    <Button variant="contained" color="inherit" href="/" sx={{ fontSize: "18px", position: "relative", width: '200px', height: '50px', }}>
                         タイトル画面へ
                     </Button>
                 </Box>


### PR DESCRIPTION
## 関連

- なし

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [x] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [x] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

**`app/src/components/Game/gameClearCompornent.tsx`**

- タイトルへ戻るリンクが指定する必要のないファイルを指定していたため修正

## 動作確認

- タイトルへ戻るボタンでタイトルへ戻ることを確認

## その他

- なし