### PR TITLE
ミニゲームの確率と制限時間の調節

### DIFF
--- a/app/src/components/Game/index.tsx
+++ b/app/src/components/Game/index.tsx
@@ -331,16 +331,15 @@ export const GameComponent = ({ score }: { score?: number }) => {
                     <GameClearComponent />
                 </div>
             )}
-            {(turn == 2 && Minigame == 0) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><BokeEvaluation /></div> :
-                (turn == 2 && Minigame == 1) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Bokes /></div> :
-                    (turn == 2 && Minigame == 2) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Pelmanism pairNumber={5} /></div> :
-                        (turn == 2 && Minigame == 3 && (i1 < 3 || i3 > 39)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="大阪" /></div> :
-                            (turn == 2 && Minigame == 3 && (i1 < 8)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="和歌山" /></div> :
-                                (turn == 2 && Minigame == 3 && (i1 < 13)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="奈良" /></div> :
-                                    (turn == 2 && Minigame == 3 && (i1 < 20)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="三重" /></div> :
-                                        (turn == 2 && Minigame == 3 && (i1 < 25)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="滋賀" /></div> :
-                                            (turn == 2 && Minigame == 3 && (i1 < 30)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="京都" /></div> :
-                                                (turn == 2 && Minigame == 3 && (i1 < 40)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="兵庫" /></div> : <div />}
+            {(turn == 2 && Minigame == 0) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Bokes /></div> :
+                (turn == 2 && Minigame >= 1 && Minigame <= 2) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Pelmanism pairNumber={5} /></div> :
+                    (turn == 2 && Minigame == 3 && (i1 < 3 || i3 > 39)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="大阪" /></div> :
+                        (turn == 2 && Minigame == 3 && (i1 < 8)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="和歌山" /></div> :
+                            (turn == 2 && Minigame == 3 && (i1 < 13)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="奈良" /></div> :
+                                (turn == 2 && Minigame == 3 && (i1 < 20)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="三重" /></div> :
+                                    (turn == 2 && Minigame == 3 && (i1 < 25)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="滋賀" /></div> :
+                                        (turn == 2 && Minigame == 3 && (i1 < 30)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="京都" /></div> :
+                                            (turn == 2 && Minigame == 3 && (i1 < 40)) ? <div style={{ zIndex: 1, position: 'fixed', top: 0, left: 0, width: '100%', height: '100%' }}><Quizzes prefecture="兵庫" /></div> : <div />}
             {(turn == 3 && Minigame >= 0) ? <Mini_init /> : <div />}
             <Grid container xs={12} >
                 <Grid item>

--- a/app/src/features/pelmanism/components/Pelmanism.tsx
+++ b/app/src/features/pelmanism/components/Pelmanism.tsx
@@ -33,7 +33,7 @@ export function Pelmanism({ pairNumber }: { pairNumber: number }) {
 
   useEffect(() => {
     if (isGameStarted) {
-      setTimeLeft(1); // 初期化
+      setTimeLeft(25); // 初期化
     }
   }, [isGameStarted]); // ゲーム開始時にtimeLeftを10に初期化
 


### PR DESCRIPTION
## 関連

<!--
- 関連するPull request, Issueなど
-->

## 変更の概要
ミニゲームの確率と制限時間の調節
<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [X] フロントエンド
-   [ ] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細
ミニゲームの確率を神経衰弱がよく出るように少し上げた
神経衰弱の制限時間を5秒に調節
<!--
- 変更の詳細をなるべく具体的に記載して下さい
 -->

## 動作確認

<!--
- どのような動作確認をしたのか？見つかった課題等はあるか？
-->

## その他

<!--
- 伝えておくべき事や，補足資料などがあれば自由に記載して下さい
-->
